### PR TITLE
Change to use middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://travis-ci.org/benjaminhadfield/redux-data-dispatch.svg?branch=master)](https://travis-ci.org/benjaminhadfield/redux-data-dispatch)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
-An enhancer to redux reducers that makes it easy to define dependend reducers to store data returned by a single action. This promotes a modular redux design where each reducer is responsible for storing one type of data.
+An enhancer to redux reducers that makes it easy to define dependent reducers to store data returned by a single action. This promotes a modular redux design where each reducer is responsible for storing one type of data.
 
 This package works best when used in conjunction with [Normalizr](https://github.com/paularmstrong/normalizr).
 
@@ -49,15 +49,15 @@ import reducer from './reducer'
 import App from './App'
 
 // Setup the store with middleware
-const store = createStore(
+const store = (initialState) => createStore(
   reducer,
-  undefined,
+  initialState,
   applyMiddleware(dataDispatch)
 )
 
 // Render the app
 ReactDOM.render(
-  <Provider store={store}>
+  <Provider store={store()}>
     <App />
   </Provider>,
   document.getElementById('root')
@@ -67,8 +67,7 @@ ReactDOM.render(
 ```js
 // src/services/repo/actions.js
 
-// import dataDispatch from index.js
-import api from '../api'
+import axios from 'axios'
 import { repo } from './schema'
 
 // action types
@@ -84,8 +83,7 @@ const getReposFailure = payload => ({ type: GET_REPOS_FAILURE, error: true, payl
 // action to get repos from github
 export const getRepos = (repoName) => (dispatch) => {
   dispatch(getReposRequest())
-  return api({
-    url: `https://api.github.com/search/repositories`,
+  return axios.get('https://api.github.com/search/repositories', {
     params: { q: repoName }
   })
     // normalize the response to get response data in shape:
@@ -133,7 +131,7 @@ export default listenFor('owner')(reducer)
 
 ## API
 
-### dataDispatch `function`
+### `dataDispatch` `<function>`
 
 ```js
 import dataDispatch from 'redux-data-dispatch'
@@ -141,7 +139,7 @@ import dataDispatch from 'redux-data-dispatch'
 
 Supply to `applyMiddleware` to add data dispatch functionality to your app.
 
-##### Example
+#### Example
 
 ###### `store.js`
 
@@ -166,17 +164,17 @@ const doSomething = () => dispatch => {
 }
 ```
 
-### listenFor `function`
+### `listenFor` `<function>`
 
 ```js
 import { listenFor } from 'redux-data-dispatch'
 ```
 
-##### Arguments
+#### Arguments
 
- - `key` <`string`> a key that uniquely identifies this reducer.
+ - **`key`** `<string>`: a key that uniquely identifies this reducer.
 
-##### Returns
+#### Returns
 
 Returns a function that accepts the reducer to identify with `key`.
 

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.setupTree = exports.listenFor = exports.DATA_TREE_ID = undefined;
+exports.dataDispatch = exports.setupTree = exports.listenFor = exports.DATA_TREE_ID = undefined;
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
@@ -60,5 +60,40 @@ var setupTree = exports.setupTree = function setupTree(store) {
     store.dispatch(action);
     // Return the original action
     return action;
+  };
+};
+
+/**
+ * Throws error if the dependency values are not strings or functions.
+ * @param {object} deps
+ */
+var _checkDependencyObject = function _checkDependencyObject(deps) {
+  Object.keys(deps).map(function (key) {
+    if (typeof deps[key] !== 'function' && typeof deps[key] !== 'string') {
+      throw new TypeError('Dependent reducer values must be either a function or a string, but got ' + _typeof(deps[key]) + ' for ' + key);
+    }
+  });
+};
+
+var dataDispatch = exports.dataDispatch = function dataDispatch(store) {
+  return function (next) {
+    return function (action) {
+      var deps = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+      _checkDependencyObject(deps);
+      // Call dependent actions
+      Object.keys(deps).map(function (key) {
+        var _subAction2;
+
+        var subAction = (_subAction2 = {}, _defineProperty(_subAction2, DATA_TREE_ID, true), _defineProperty(_subAction2, 'type', Symbol.for('dataTree.' + key)), _defineProperty(_subAction2, 'payload', typeof deps[key] === 'function'
+        // dep value is function -> run function on action to get the value
+        ? deps[key](action)
+        // dep value is string -> access action property
+        : (0, _utils.dotCaseToObjectProperty)(action, deps[key])), _subAction2);
+        store.dispatch(subAction);
+      });
+      // dispatch original action
+      return next(action);
+    };
   };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,11 +3,12 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.DATA_TREE_ID = exports.listenFor = exports.setupTree = undefined;
+exports.dataDispatch = exports.DATA_TREE_ID = exports.listenFor = exports.setupTree = undefined;
 
 var _core = require('./core');
 
 exports.setupTree = _core.setupTree;
 exports.listenFor = _core.listenFor;
 exports.DATA_TREE_ID = _core.DATA_TREE_ID;
+exports.dataDispatch = _core.dataDispatch;
 exports.default = _core.setupTree;

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -30,31 +30,32 @@ export const listenFor = (key) => {
 }
 
 /**
- * Takes an action and a dependency mapping of form:
- * { [name]: action.payload.entities.[entityName] }
- * where [name] must match the key given to connect
+ * Throws error if the dependency values are not strings or functions.
+ * @param {object} deps
  */
-export const setupTree = (store) => {
-  return function (action, deps = {}) {
-    Object.keys(deps).map(key => {
-      if (typeof deps[key] !== 'function' && typeof deps[key] !== 'string') {
-        throw new TypeError('Dependent reducer values must be either a function or a string, but got ' + typeof deps[key] + ' for ' + key)
-      }
-    })
-    // Dispatch any dependent actions
-    Object.keys(deps).map(key => {
-      const subAction = {
-        [DATA_TREE_ID]: true,
-        type: Symbol.for(`dataTree.${key}`),
-        payload: typeof deps[key] === 'function'
-          ? deps[key](action)
-          : dotCaseToObjectProperty(action, deps[key])
-      }
-      store.dispatch(subAction)
-    })
-    // Dispatch the original action
-    store.dispatch(action)
-    // Return the original action
-    return action
-  }
+const _checkDependencyObject = deps => {
+  Object.keys(deps).map(key => {
+    if (typeof deps[key] !== 'function' && typeof deps[key] !== 'string') {
+      throw new TypeError('Dependent reducer values must be either a function or a string, but got ' + typeof deps[key] + ' for ' + key)
+    }
+  })
+}
+
+export const dataDispatch = store => next => (action, deps = {}) => {
+  _checkDependencyObject(deps)
+  // Call dependent actions
+  Object.keys(deps).map((key) => {
+    const subAction = {
+      [DATA_TREE_ID]: true,
+      type: Symbol.for(`dataTree.${key}`),
+      payload: typeof deps[key] === 'function'
+        // dep value is function -> run function on action to get the value
+        ? deps[key](action)
+        // dep value is string -> access action property
+        : dotCaseToObjectProperty(action, deps[key])
+    }
+    store.dispatch(subAction)
+  })
+  // dispatch original action
+  return next(action)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { setupTree, listenFor, DATA_TREE_ID } from './core'
+import { dataDispatch, listenFor, DATA_TREE_ID } from './core'
 
-export { setupTree, listenFor, DATA_TREE_ID }
-export default setupTree
+export { dataDispatch, listenFor, DATA_TREE_ID }
+export default dataDispatch


### PR DESCRIPTION
Dependent actions are now submitted in middleware as opposed to an external function. This is more compact and means the user doesn't need to write as much setup code :)

Fixes #1.

- [x] Change to use middleware
- [x] Update tests
- [x] Update readme